### PR TITLE
Fix get history input value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,61 +6,89 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Filtered channel list by number of members is now used to get channel history to filter on time.
+
+### Updated
+
+- Getting the channel history now is inlcusive by the latest date in each channel.
+
 ## [v0.3.4]
+
 ### Added
+
 - Docker support
 - Package version now pull from package.json
 - Keywords to package.json
 
 ### Fixed
+
 - Removed extra console log
 
 ## [v0.3.3] - 2017-10-13
+
 ### Changed
+
 - Removed `Private` flag in package.json to publish to NPM
 
 ## [v0.3.2] - 2017-10-13
+
 ### Added
+
 - LICENSE
 - `-b, --basic` option default setting documentation
 
 ### Changed
+
 - README and help documentation for the `-b, --basic` option to reflect what the option is used for
 - CHANGELOG format
 - Updated Yarn and NPM install methods to pull from NPM
 
 ## v0.3.1 - 2017-09-22
+
 ### Added
+
 - added a -b --basic option so allow for basic stdout for cron and task runner tools
 
 ## v0.3.0 - 2017-09-22
+
 ### Changed
+
  - refactored the code so requests are throttled to 1 per 2 sec
 
 ## v0.2.4 - 2017-08-11
+
 ### Fixed
+
 - fixed a bug in input name for channel list params
 
 ## v0.2.3 - 2017-08-08
+
 ### Fixed
+
 - Fix typos in recent README changes
 
 ## v0.2.2 - 2017-08-08
+
 ### Changed
+
 - updated stdout to use console log
 
 ## v0.2.1 - 2017-08-08
+
 ### Changed
+
 - updated error out to use console error
 
 ## v0.1.1 - 2017-07-26
+
 ### Changed
+
 - Fixed typos all over
 
 ## v0.1.0 - 2017-07-26
-### Added
-- All the things
 
-[Unreleased]: https://github.com/wearefine/slack-archive-bot/compare/v0.3.3...HEAD
-[v0.3.3]: https://github.com/wearefine/slack-archive-bot/compare/v0.3.2...v0.3.3
-[v0.3.2]: https://github.com/wearefine/slack-archive-bot/compare/v0.3.1...v0.3.2
+### Added
+
+- All the things

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 FINE Design Group, Inc.
+Copyright (c) 2018 FINE Design Group, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/history_resp.json
+++ b/history_resp.json
@@ -1,0 +1,16 @@
+{
+  "ok": true,
+  "latest": "1525711663329",
+  "messages": [
+    {
+      "text": "",
+      "bot_id": "B951991NC",
+      "attachments": [
+        {}
+      ],
+      "type": "message",
+      "subtype": "bot_message",
+      "ts": "1525698330.000450"
+    }
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ const now = moment().unix();
 const exclude_members = true;
 const exclude_archived = true;
 const count = 1;
+const inclusive = true;
+const latest = moment.now();
 
 // Init some arrays
 let oneOrLess = [];
@@ -109,7 +111,7 @@ function filterChannels() {
 function getHistory(channels) {
   let done
   if (!basic) {
-    done = elegantStatus(`Fetching channel history -- ${channels.length}`);
+    done = elegantStatus(`Fetching channel history for ${channels.length} channel(s)`);
   }
   let channelIndex = -1;
   let timeout = setInterval(function () {
@@ -125,13 +127,13 @@ function getHistory(channels) {
         done.updateText(`Fetching channel history -- ${channelIndex+1}/${channels.length}`)
       }
       let channel = channels[channelIndex].id
-      slack.channels.history({ token, channel, count }, (err, data) => {
+      slack.channels.history({ token, channel, count, inclusive, latest }, (err, data) => {
         if (err) {
           if (!basic) {
-            done.updateText(error(`Error fetching channel ${channel.name} with error: ${err}`));
+            done.updateText(error(`Error fetching channel ${channel.name} with ${err}`));
             done(false);
           } else {
-            console.log(error(`Error fetching channel ${channel.name} with error: ${err}`));
+            console.error(error(`Error fetching channel ${channel.name} with ${err}`));
           }
         }
         if (moment.duration(now - data.messages[0].ts, 's').asDays() > inactiveDays) {
@@ -167,5 +169,5 @@ slack.channels.list({ token, exclude_archived, exclude_members }, (err, data) =>
   if (!basic) {
     done(true)
   }
-  getHistory(data.channels);
+  getHistory(oneOrLess);
 });


### PR DESCRIPTION
The channel history input was not using the prefiltered input. It has been updated to use the value from the members count filter. 